### PR TITLE
Add NCC trails and paths layer

### DIFF
--- a/Container.svg
+++ b/Container.svg
@@ -65,5 +65,7 @@
 <animation xlink:href="./liveCams/Alberta/webcam.svg" x="-30000" y="-30000" width="60000" height="60000" title="Alberta (511 Alberta)" visibility="hidden" opacity="0.7" class="Canadian_RoadLiveCameras"/>
 <animation xlink:href="./liveCams/BritishColumbia/webcam.svg" x="-30000" y="-30000" width="60000" height="60000" title="British Columbia (Drive BC)" visibility="hidden" opacity="0.7" class="Canadian_RoadLiveCameras"/>
 
+<!-- Canadian trails / paths -->
+<animation xlink:href="./trails/nccPathTrails/NCCPathTrails.svg" x="-3000" y="-3000" width="6000" height="6000" title="NCC Path Data" visibility="hideen" class="Canadian_Trails clickable"/>
 
 </svg>

--- a/Container.svg
+++ b/Container.svg
@@ -66,6 +66,6 @@
 <animation xlink:href="./liveCams/BritishColumbia/webcam.svg" x="-30000" y="-30000" width="60000" height="60000" title="British Columbia (Drive BC)" visibility="hidden" opacity="0.7" class="Canadian_RoadLiveCameras"/>
 
 <!-- Canadian trails / paths -->
-<animation xlink:href="./trails/nccPathTrails/NCCPathTrails.svg" x="-3000" y="-3000" width="6000" height="6000" title="NCC Path Data" visibility="hideen" class="Canadian_Trails clickable"/>
+<animation xlink:href="./trails/nccPathTrails/NCCPathTrails.svg" x="-3000" y="-3000" width="6000" height="6000" title="NCC Path Data" visibility="hidden" class="Canadian_Trails clickable"/>
 
 </svg>

--- a/trails/nccPathTrails/NCCPathTrails.html
+++ b/trails/nccPathTrails/NCCPathTrails.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+
+<head>
+    <title>NCC Paths and Trails</title>
+    <meta charset="utf-8">
+    </meta>
+</head>
+<script src="NCCPathTrails.js"></script>
+
+<body>
+    <h1>NCC Paths and Trails</h1>
+
+    <div id="messageDiv">
+        <p>Source: <a href="https://arcg.is/0P18bj" target="_blank">NCC Open Data</a></p>
+    </div>
+</body>
+
+</html>

--- a/trails/nccPathTrails/NCCPathTrails.js
+++ b/trails/nccPathTrails/NCCPathTrails.js
@@ -1,0 +1,61 @@
+const baseUrl = "https://services2.arcgis.com/WLyMuW006nKOfa5Z/arcgis/rest/services/NCC_Paths_and_Trails/FeatureServer/1/";
+
+const onload = () => {
+    addEventListener("zoomPanMap", getPathsNCC);
+    getPathsNCC();
+}
+
+async function getPathsNCC() {
+    const queryUrl = buildQuery(); // Building the full url 
+    const pathData = await getData(queryUrl); // Fetching the data from the NCC's Paths/Trails API
+    if (pathData === undefined) return; // Exiting early if the API request has failed
+    drawPaths(pathData); // Drawing the paths from the geoJson Data
+}
+
+function buildQuery() {
+    const query = `${baseUrl}query?where=1%3D1&outFields=*&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelEnvelopeIntersects&outSR=4326&f=geojson`
+    return (query);
+}
+
+async function getData(url) {
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`Response status: ${response.status}`);
+        }
+        const body = JSON.parse(await response.text());
+        return body;
+    } catch (err) {
+        console.error(err);
+    }
+    return undefined;
+}
+
+function drawPaths(pathData) {
+    const metaSchema = buildSchema(pathData.features);
+    const parentElement = svgImage.getElementById("mapContents");
+    removeChildren(parentElement);
+    svgMapGIStool.drawGeoJson(pathData.features, layerID, "blue", 0, "blue", "p0", "poi", "", parentElement, metaSchema);
+    svgMap.refreshScreen();
+}
+
+function buildSchema(features) {
+    // Generates a normalized schema from the property names of geojson features
+    let metaSchema = {};
+    for (const feature of features) {
+        for (const propName in feature.properties) {
+            if (!metaSchema[propName]) {
+                metaSchema[propName] = true;
+            }
+        }
+    }
+    metaSchema = Object.keys(metaSchema);
+    // moving the OBJECTID param to the end -- not useful for at-a-glance readability
+    metaSchema.push(metaSchema.shift());
+    svgImage.documentElement.setAttribute("property", metaSchema.join());
+    return metaSchema;
+}
+
+function removeChildren(element) {
+    while (element.firstChild) element.removeChild(element.firstChild);
+}

--- a/trails/nccPathTrails/NCCPathTrails.svg
+++ b/trails/nccPathTrails/NCCPathTrails.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="120,-50,30,30" data-controller="NCCPathTrails.html#exec=appearOnLayerLoad">
+ <globalCoordinateSystem srsName="http://purl.org/crs/84" transform="matrix(1,0,0,-1,0,0)"/>
+
+  <defs>
+  <g id="p0">
+    <circle cx="0" cy="0" r="6" fill="blue"/>
+  </g>
+  </defs>
+  <g id="mapContents"></g>
+</svg>

--- a/trails/nccPathTrails/NCCPathTrails.svg
+++ b/trails/nccPathTrails/NCCPathTrails.svg
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="120,-50,30,30" data-controller="NCCPathTrails.html#exec=appearOnLayerLoad">
- <globalCoordinateSystem srsName="http://purl.org/crs/84" transform="matrix(1,0,0,-1,0,0)"/>
-
+  <globalCoordinateSystem srsName="http://purl.org/crs/84" transform="matrix(1,0,0,-1,0,0)"/>
   <defs>
   <g id="p0">
     <circle cx="0" cy="0" r="6" fill="blue"/>


### PR DESCRIPTION
Adding an NCC Path and Trails layer, using geoJson from [NCC Open Data](https://ncc-hub-ncc-ccn.hub.arcgis.com/datasets/c0b7abc0c9a74a0285807ea257ae4e00_1/explore?location=45.431233%2C-75.753778%2C10).

Notes:
- Currently placed under "Canadian_Trails" -- can be be placed in a different category if needed

Sample image:
<img width="2508" height="1454" alt="image" src="https://github.com/user-attachments/assets/ebd9ffbf-1975-4ff0-92ff-4bb3b273b629" />
