### PR TITLE
Adding Canada Elevation Basemap layer

### DIFF
--- a/Container.svg
+++ b/Container.svg
@@ -59,6 +59,9 @@
 
 <!-- "The following are the Canada layers stored in this canadianSvgmapAppLayers repository. -->
 
+<!-- Canadian Basemaps -->
+<animation xlink:href="./basemaps/canadaElevation/canadaElevation.svg" x="-3000" y="-3000" width="6000" height="6000" title="Canada Elevation Map" visibility="hidden" class="Canadian_Basemaps"/>
+
 <!-- Canadian road libecams -->
 <animation xlink:href="./liveCams/Ottawa/webcam.svg" x="-30000" y="-30000" width="60000" height="60000" title="Ottawa City" visibility="hidden" opacity="0.7" class="Canadian_RoadLiveCameras"/>
 <animation xlink:href="./liveCams/Quebec/webcam.svg" x="-30000" y="-30000" width="60000" height="60000" title="Québec (Données Québec)" visibility="hidden" opacity="0.7" class="Canadian_RoadLiveCameras"/>

--- a/basemaps/canadaElevation/canadaElevation.html
+++ b/basemaps/canadaElevation/canadaElevation.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html>
+
+<head>
+    <title>Canada Basemap - Elevation (CBME)</title>
+    <meta charset="utf-8">
+    </meta>
+</head>
+<script src="https://cdn.jsdelivr.net/gh/svgmap/svgmapjs@latest/svgMapLayerLib.js"></script>
+<script>
+    const baseUrl = "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+
+    let renderLayerId = undefined;
+    let renderLayer = undefined;
+    let apiParams = undefined;
+
+    // Map blend mode
+    const blendModeMap = new Map([
+        ["normal", true],
+        ["multiply", true],
+        ["darken", true],
+        ["color-burn", true],
+    ])
+
+    let currBlendMode = "normal"; // Current blend mode
+
+    const setBlendMode = (blendMode) => {
+        if (!blendModeMap.has(blendMode)) return;
+        if (!renderLayer) return;
+        currBlendMode = blendMode;
+        renderLayer.style.mixBlendMode = currBlendMode;
+    }
+
+    addEventListener("DOMContentLoaded", () => {
+        const blendModeSelector = document.getElementById("blendModeSelector");
+        for (const blendMode of blendModeMap.keys()) {
+            const newOption = document.createElement("option");
+            newOption.value = blendMode;
+            newOption.text = blendMode;
+            blendModeSelector.appendChild(newOption);
+        }
+    })
+
+    function preRenderFunction(svgDocStatus) {
+        if (!svgDocStatus || !svgDocStatus.actualViewBox) return;
+        const box = svgDocStatus.actualViewBox;
+        getElevationMap(box);
+    }
+
+    const fetchParams = async (url) => {
+        try {
+            const res = await fetch(`${url}?f=pjson`);
+            const body = JSON.parse(await res.text());
+            return body;
+        } catch (error) {
+            console.error(`Error fetching API parameters: ${error}`);
+        }
+        return undefined;
+    }
+
+
+    const buildTileQuery = (x, y, z) => {
+        const url = `${baseUrl}/tile/${z}/${y}/${x}`
+        return url;
+    }
+
+    const getElevationMap = async (box) => {
+        if (!apiParams) apiParams = await fetchParams(baseUrl);
+
+        const R = 6378137;
+        const deg2rad = Math.PI / 180;
+        const svgToMeters = deg2rad * R;
+
+        const viewMinX = box.x * svgToMeters;
+        const viewMaxY = -(box.y) * svgToMeters;
+        const viewWidth = box.width * svgToMeters;
+        const viewHeight = box.height * svgToMeters;
+
+        const viewMaxX = viewMinX + viewWidth;
+        const viewMinY = viewMaxY - viewHeight; // Bottom
+
+        const tileOriginX = apiParams.tileInfo.origin.x;
+        const tileOriginY = apiParams.tileInfo.origin.y;
+        const tileSize = apiParams.tileInfo.rows;
+
+        let z = 0;
+        const screenWidthPx = 1024;
+        const currentViewResolution = viewWidth / screenWidthPx;
+
+        for (let i = 0; i < apiParams.tileInfo.lods.length; i++) {
+            if (apiParams.tileInfo.lods[i].resolution < currentViewResolution) {
+                z = i > 0 ? i : 0;
+                break;
+            }
+            z = i;
+        }
+
+        const tileMeters = tileSize * apiParams.tileInfo.lods[z].resolution;
+        const minTileX = Math.floor((viewMinX - tileOriginX) / tileMeters);
+        const maxTileX = Math.floor((viewMaxX - tileOriginX) / tileMeters);
+        const minTileY = Math.floor((tileOriginY - viewMaxY) / tileMeters);
+        const maxTileY = Math.floor((tileOriginY - viewMinY) / tileMeters);
+
+        const tileLayer = svgImage.getElementById('tileLayer');
+        while (tileLayer.firstChild) { tileLayer.removeChild(tileLayer.firstChild); }
+
+        for (let x = minTileX; x <= maxTileX; x++) {
+            for (let y = minTileY; y <= maxTileY; y++) {
+                if (x < 0 || y < 0) continue;
+                const url = buildTileQuery(x, y, z);
+                const drawMetersX = tileOriginX + (x * tileMeters);
+                const drawMetersY = tileOriginY - (y * tileMeters);
+
+                const drawSvgX = drawMetersX / svgToMeters;
+                const drawSvgY = -drawMetersY / svgToMeters; // Y軸反転
+                const drawSvgWidth = tileMeters / svgToMeters;
+                const img = svgImage.createElement("image");
+                img.setAttribute("x", drawSvgX);
+                img.setAttribute("y", drawSvgY);
+                img.setAttribute("width", drawSvgWidth);
+                img.setAttribute("height", drawSvgWidth);
+                img.setAttribute("preserveAspectRatio", "none");
+                img.setAttribute("xlink:href", url);
+                img.onerror = function() { this.style.display = 'none'; };
+                tileLayer.appendChild(img);
+            }
+        }
+
+
+        if (svgImageProps.rootLayer !== renderLayerId || !renderLayer) {
+            const renderCanvas = svgMap.getMapCanvas()
+            renderLayerId = svgImageProps.rootLayer;
+            for (const child of renderCanvas.childNodes) {
+                if (child.id === svgImageProps.rootLayer) renderLayer = child;
+            }
+        }
+    }
+</script>
+
+<body>
+    <h1>Canada Basemap - Elevation (CBME)</h1>
+    <h2>Overlay blend mode:</h2>
+    <label for="blendMode">Select a blend mode:</label>
+    <select name="blendMode" id="blendModeSelector" onchange="setBlendMode(this.value)">
+    </select>
+    <p>Source: <a href="https://open.canada.ca/data/en/dataset/974944d2-14cb-41c8-ba57-936282d5a227">Natural Resources
+            Canada</a></p>
+</body>
+
+</html>

--- a/basemaps/canadaElevation/canadaElevation.html
+++ b/basemaps/canadaElevation/canadaElevation.html
@@ -77,7 +77,7 @@
         const viewHeight = box.height * svgToMeters;
 
         const viewMaxX = viewMinX + viewWidth;
-        const viewMinY = viewMaxY - viewHeight; // Bottom
+        const viewMinY = viewMaxY - viewHeight;
 
         const tileOriginX = apiParams.tileInfo.origin.x;
         const tileOriginY = apiParams.tileInfo.origin.y;
@@ -112,7 +112,7 @@
                 const drawMetersY = tileOriginY - (y * tileMeters);
 
                 const drawSvgX = drawMetersX / svgToMeters;
-                const drawSvgY = -drawMetersY / svgToMeters; // Y軸反転
+                const drawSvgY = -drawMetersY / svgToMeters;
                 const drawSvgWidth = tileMeters / svgToMeters;
                 const img = svgImage.createElement("image");
                 img.setAttribute("x", drawSvgX);

--- a/basemaps/canadaElevation/canadaElevation.svg
+++ b/basemaps/canadaElevation/canadaElevation.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:go="http://purl.org/svgmap/profile" viewBox="global,-110,40,30,30" data-controller="canadaElevation.html#exec=appearOnLayerLoad&amp;requiredHeight=280" >
+<script>
+// カナダ標準 ランベルト正角円錐図法
+function lambertConformalConicCanada(options = {}) {
+	// =========================
+	// 設定と事前計算
+	// =========================
+	const deg2rad = Math.PI / 180;
+	const rad2deg = 180 / Math.PI;
+
+	const lat1 = (options.lat1 ?? 49) * deg2rad;
+	const lat2 = (options.lat2 ?? 77) * deg2rad;
+	const lat0 = (options.lat0 ?? 49) * deg2rad;
+	const lng0 = (options.lng0 ?? -95) * deg2rad;
+
+	const EPS = 1e-10;
+
+	const n = Math.log(Math.cos(lat1) / Math.cos(lat2)) /
+			  Math.log(Math.tan(Math.PI / 4 + lat2 / 2) / Math.tan(Math.PI / 4 + lat1 / 2));
+	const F = (Math.cos(lat1) * Math.pow(Math.tan(Math.PI / 4 + lat1 / 2), n)) / n;
+	const rho0 = F / Math.pow(Math.tan(Math.PI / 4 + lat0 / 2), n);
+
+	// =========================
+	// 内部関数（純数学）
+	// =========================
+	function forward(lat, lng) {
+		let rho = 0;
+		// 北極点でのゼロ割り・無限大発散を回避
+		if (Math.abs(Math.PI / 2 - lat) > EPS) {
+			rho = F / Math.pow(Math.tan(Math.PI / 4 + lat / 2), n);
+		}
+		
+		const theta = n * (lng - lng0);
+		const x = rho * Math.sin(theta);
+		const y = rho0 - rho * Math.cos(theta);
+		
+		if (!isFinite(x) || !isFinite(y)) return null;
+		return { x, y };
+	}
+
+	function inverse(x, y) {
+		const rho = Math.sqrt(x * x + (rho0 - y) * (rho0 - y));
+		
+		// 極点の処理
+		if (rho < EPS) {
+			return { lat: Math.PI / 2, lng: lng0 };
+		}
+		
+		// GPTの知恵: Math.atan2 を使って角度を安全に取得
+		const theta = Math.atan2(x, rho0 - y);
+		const lat = 2 * Math.atan(Math.pow(F / rho, 1 / n)) - Math.PI / 2;
+		let lng = lng0 + theta / n;
+		
+		// 経度の正規化 [-π, π]
+		if (lng > Math.PI) lng -= 2 * Math.PI;
+		if (lng < -Math.PI) lng += 2 * Math.PI;
+		
+		return { lat, lng };
+	}
+
+	// =========================
+	// 外部API (svgmap.js の仕様に厳密に準拠)
+	// =========================
+	return {
+		transform(inp) {
+			// inp は {x: 経度, y: 緯度} で渡ってくる
+			const res = forward(inp.y * deg2rad, inp.x * deg2rad);
+			if (!res) return null;
+
+			return {
+				x: res.x * rad2deg,
+				y: -res.y * rad2deg // UI用にY軸を反転
+			};
+		},
+
+		inverse(inp) {
+			// inp は {x: 描画X, y: 描画Y} で渡ってくる
+			const res = inverse(inp.x * deg2rad, -inp.y * deg2rad);
+			if (!res) return null;
+
+			return {
+				x: res.lng * rad2deg, // svgmapjsはxに経度を期待する
+				y: res.lat * rad2deg  // yに緯度を期待する
+			};
+		},
+
+		scale: 1.0
+	};
+}
+</script>
+<globalCoordinateSystem srsName="http://purl.org/crs/84" transform="lambertConformalConicCanada" />
+<g id="tileLayer"></g>
+</svg>


### PR DESCRIPTION
# Summary:
Created using the [Elevation (CBME)](https://open.canada.ca/data/en/dataset/974944d2-14cb-41c8-ba57-936282d5a227) ESRI REST API provided by Natural Resources Canada.

Includes a `setBlendMode` function, that allows for the user to toggle the `mix-blend-mode` CSS property of the rendered layer. This allows for the rendered tiles to be displayed on top of other base maps.

The layer also includes a `fetchParams` function, designed to fetch the parameters of the ESRI REST API, allowing for key calculations to be based on provider defined data, instead of statically storing it within the layer. This function could be moved to a common folder, for other future layers also built on ESRI APIs.

# Known issues:

## Projection Misalignment
There are slight discrepancies between the Elevation Map and other existing layers, such as the OpenStreetMap base layer as seen below:

<img width="1186" height="797" alt="image" src="https://github.com/user-attachments/assets/22387bb1-6330-442c-952f-674fee617759" />

This is likely due to the original tiling data being provided in the Canada Atlas Lambert CRS, requiring that it be transformed to SVGMap's default CRS. However, when overlaid with layers created using data originally in Canada Atlas Lambert, the discrepancy is not present. 



